### PR TITLE
fix: incorrect discord link for nodejs in aws course

### DIFF
--- a/docs/rs-school-chats.md
+++ b/docs/rs-school-chats.md
@@ -59,7 +59,7 @@
 - Курс «React» https://discord.com/invite/zyRcphs3px
 - Курс «Angular» https://discord.com/invite/xwReXYqvs7
 - Курс «NodeJS» https://discord.com/invite/8BFb8va
-- Курс «NodeJS in AWS» https://discord.com/invite/8BFb8va
+- Курс «NodeJS in AWS» https://discord.com/invite/ATsHAqCsnw
 - Курс «Разработка приложений для Android» https://discord.com/invite/AzKUfTZ
 - Курс «Разработка приложений для iOS» https://discord.com/invite/HCmpatx
 - Курс «Введение в машинное обучение» https://discord.gg/EaqnbAAUps


### PR DESCRIPTION
Fixed incorrect discord link for NodeJS in AWS course
Closes issue #243 