### PR TITLE
Sync mentoring section: Add missing mentor documentation to EN

### DIFF
--- a/docs/en/docsMenu_en.json
+++ b/docs/en/docsMenu_en.json
@@ -203,7 +203,7 @@
     "title": "Mentoring",
     "items": [
       {
-        "title": "Mentor",
+        "title": "How to Become a Mentor?",
         "link": "rs-school-mentor"
       },
       {
@@ -211,7 +211,19 @@
         "link": "pair-mentoring"
       },
       {
-        "title": "Pull Request Review Process",
+        "title": "Registration and Getting Students",
+        "link": "mentoring-kick-off"
+      },
+      {
+        "title": "First Interview",
+        "link": "mentoring-first-interview"
+      },
+      {
+        "title": "Mentoring Process",
+        "link": "mentoring"
+      },
+      {
+        "title": "Mentor Assignment Review",
         "link": "pull-request-review-process"
       }
     ]

--- a/docs/en/mentoring-first-interview.md
+++ b/docs/en/mentoring-first-interview.md
@@ -1,0 +1,121 @@
+# First Interview with Students (Technical screening)
+
+## 1. Before the Interview
+
+### 1.1 Read Information About the Interview from the Student Curriculum
+https://github.com/rolling-scopes-school/tasks/tree/master/stage2/modules/technical-screening
+
+### 1.2. Choose Interview Format
+- 1-on-1 with a student or in a pair with a second mentor. 
+- In case of offline interview, you can interview a group of students at once. 
+
+### 1.3. Choose Location
+- Online (MS Teams, Google Meet, Skype) or offline (office, cafe, coworking space, etc.)
+- **Format:** We strongly recommend conducting interviews with the camera turned on. This helps establish contact and reduces the risk of cheating.
+- The following tools may be useful for online interviews:
+    - https://codepen.io/
+    - https://codeshare.io/
+    - https://www.skype.com/en/interviews/
+    - https://codepad.remoteinterview.io
+    - https://repl.it/
+
+### 1.4. Agree on Time and Place  
+Students should contact you themselves; they have the contacts you provided in RS App.
+If you don't want to wait, you need to:
+1. View the list of students assigned to you for interview: RS APP > Interviews > Technical Screening
+2. Use student contact information from their profile in RSAPP or find the student in Discord by their GitHub account
+
+### 1.5. Review Student Information
+- Information from the student's profile in RS APP.
+- Student's rating in RS APP > Score.
+- Read the CV that students created as part of one of the assignments. It's in the student's **personal** GitHub repository `rsschool-cv`. (Attention! There may be fake data) 
+- Watch the student's self-introduction video. The link to the recording is in the student's private repository on the RS School account in the "self-introduction" branch. 
+- Review the student's layout work. You can and should ask additional questions during the interview. Links to tasks are in score.
+- Review the student's algorithmic tasks. You can and should ask additional questions during the interview. Links to tasks are in score.
+
+## 2. During the Interview
+**It's important to be polite during the interview and understand that students are usually very nervous.** 
+
+### 2.1 EXAMPLE Interview Structure
+1) Mentor tells about themselves. About 5+ sentences is enough
+2) Ask the student to tell about themselves
+  - Work experience in any field
+  - Where they studied
+  - Motivation to learn frontend
+  - anything else you want:)
+3) Light theory and a simple task so the student can get used to the interview atmosphere.
+  - example HTML questions
+    * difference between block and inline elements
+    * Display attribute values
+    * Selector weights
+    * Pseudo-classes
+    * Box model
+    * em vs rem, relative and absolute values
+    * required attributes
+    * data-attribute
+  - Example tasks
+    * palindrome
+    * removing duplicates from an array
+4) Rest of theory and practice. Mentor fills out the feedback form - RS APP > Interviews > Technical Screening
+5) Check English level (by eye :))
+6) Mentor gives feedback to the student 
+	- What topics the student answered well
+	- What needs to be worked on. Recommendations.
+	- Your decision (if you already have one)
+
+### 2.2 Possible Questions During the Interview
+If you're interviewing several people at once, you can write questions on a board, and students write answers in any order:
+- Array vs List. Write the main differences. Draw a representation. 
+- Draw a binary tree or hash table diagram on a board or sheet of paper.
+- Implement a Stack.
+- Convert decimal to binary. Give several numbers. Write (draw) the conversion algorithm.
+- Implement an array sorting function. Write what other algorithms exist. Specify Big O
+- You can ask to implement some task: 
+```
+a.
+	"aabbbcccc" - >  "2a3b4c"
+	"aaaaaaa" -> "7a"
+b. 
+	"((a))" -> true
+	"((vvv()" -> false
+c. Calculate the number of ones in binary representation:
+	31 -> 5
+	1 -> 1
+	15 -> 4
+d. Any other (e.g., palindrome check, etc.)
+```
+
+- Why did you decide to become a frontend developer? What new things have you learned in the past year and from what sources?
+- Any other questions
+- Questions about stage#1 assignments. List of assignments here - https://github.com/rolling-scopes-school/tasks/tree/master/stage1
+
+## 3. After the Interview
+Interview results must be entered into the form - RS APP > Interviews > Technical Screening.
+- Students will not see your interview feedback.
+- After conducting all interviews in your subgroup, you inform students of the result. You can postpone the final decision for a couple of weeks and see how the first assignments of the second stage are completed.   
+- If you don't take the student further, you need to indicate what problems they had and what they need to work on.
+
+Attention! Results must be submitted for all interviews, otherwise rejected students won't be added to the waitlist! 
+
+## FAQ
+#### Question: What to do if a student didn't contact you?
+Expel the student in RS APP > Expel/Unassign Student, indicating "Did not contact". 
+
+#### Question: Where can I pick up more students?
+Option #1. If you want to take another student for an interview:
+- Open RS APP > Interviews > Available students
+- Click "Want To Interview"
+
+Option #2. Ask in your city's Telegram channel - which students are left without a mentor. [List of channels](https://docs.rs.school/#/rs-school-chats?id=telegram). Then proceed as in option #1.
+
+In both options, the mentor contacts the student themselves
+
+#### Question: How to exchange students with another mentor?
+After mutual agreement of mentors, open RS APP > Interviews > Technical Screening and click "Transfer".
+
+#### Question: Do I need to interview friends/colleagues whom I mentor?
+Yes, it's necessary. You can ask another mentor to help you.
+Leave feedback in RS APP > Interviews > Technical Screening
+
+#### Question: How much time is usually allocated for an interview? 
+45-90 minutes

--- a/docs/en/mentoring-kick-off.md
+++ b/docs/en/mentoring-kick-off.md
@@ -1,0 +1,92 @@
+# Mentoring. Registration and Getting Students
+
+## 1. Mentor Registration
+#### 1.1. Registration in RS APP
+1. To become a mentor, you need to fill out the form - [app.rs.school/registry/mentor](https://app.rs.school/registry/mentor).
+2. Some time after registration (from a week to several months), the mentor receives an assignment to the course.
+You will receive a message to your specified email (and/or Telegram account) asking you to confirm registration and an invitation to an organizational webinar.
+During registration confirmation, mentors can specify:
+    - Preferences for student location (your city, country, or random location).
+    - The number of students the mentor wants to mentor.
+    - Friends/colleagues whom the mentor wants to mentor. Keep in mind that corejs interview, interviews at EPAM JSLab will be conducted by another mentor/interviewer, and some assignments are checked through cross-check, jury, etc. If your acquaintance is not on the list, ask them to register for the course - [app.rs.school/registry/student](https://app.rs.school/registry/student).
+3. After confirming registration, you will receive:
+  - Access to the mentor chat
+  - Information about the introductory session for mentors
+
+#### 1.2. Communication Channels
+- Telegram channel for mentors. You receive the channel link after confirming registration
+- Weekly meeting for mentors. Takes place once a week. Duration 30 minutes. Participation is optional. The meeting is recorded, meeting notes are sent to Telegram. 
+- [Chats where students communicate. Discord and Telegram](https://docs.rs.school/#/rs-school-chats) 
+- Closed group of activists and mentors in Discord. Here we discuss the educational process, platform, and everything related to learning at RS School. How to get access to the group is described below.
+- Getting mentor role in Discord
+  1. Open - https://app.rs.school/profile
+  2. Authorize through Discord in the `Discord Integration` block  
+  3. Add your GitHub name to your Discord nickname https://docs.rs.school/#/rs-school-chats?id=discord
+  4. Write a message in the Discord channel [#mentoring](https://discord.gg/fBvpUURPVm). Example message: "Hi everyone, my name is Juan and I'm a mentor from Colombia"
+
+#### 1.3. Getting Access to Private Student Repositories
+1. All students work with private GitHub repositories of RS School https://github.com/rolling-scopes-school
+2. All mentors are added to a separate GitHub Team.
+You can check your invite here - https://github.com/orgs/rolling-scopes-school/invitation
+3. Mentors have access to all student repositories for this course.
+4. By default, mentors are subscribed to all changes in student repositories. You can unsubscribe in GitHub settings (Profile>Settings>Notifications>Automatically watch repositories) or using the script - https://github.com/Shastel/runsubscribe
+
+#### 1.4. Getting Familiar with the Curriculum and Schedule
+The course consists of 4 stages: preparatory and three main stages. Mentors help students during the second and third stages. You need to register separately for each mentoring stage.  
+Curriculum:  
+  - [Preparatory stage. Students learn without mentor assistance.](https://github.com/rolling-scopes-school/tasks/tree/master/stage0)
+  - [First stage of training. Students learn without mentor assistance.](https://github.com/rolling-scopes-school/tasks/tree/master/stage1)
+  - [Second stage of training. Mentoring.](https://github.com/rolling-scopes-school/tasks/tree/master/stage2)
+  - Third stage of training. Mentoring. Students choose a framework:  
+     - [React](https://github.com/rolling-scopes-school/tasks/tree/master/react)
+     - [Angular](https://github.com/rolling-scopes-school/tasks/tree/master/angular)
+
+## 2. Getting Students
+### 2.1. Algorithm for Distributing Students to Mentors
+#### Step #1 Mentors Confirm Course Registration
+- Mentor confirms course registration - https://app.rs.school/course/mentor/confirm?course={courseId}. 
+- During registration confirmation, the mentor: 
+    - can add friends/colleagues they want to mentor to their group.
+    - specifies the number of students they want to mentor
+    - leaves preferences for student location
+    - if necessary, the mentor can change these parameters by submitting the confirmation form again
+#### Step #2 Random Distribution of Students to Mentors
+- Takes place on the student distribution day
+- If the mentor has free spots, they receive random students. 
+    1. If one free spot remains - 2 random students
+    2. If two or more spots remain - desired number of students plus two.
+- Each mentor is assigned a minimum of 4 interviews
+- Mentor preferences for student location are taken into account
+	- Mentor and students from the same city 
+	- Mentor and students from the same country 
+- Students of different skill levels. (For example, first by score, Nth by score, 2Nth by score, etc.)
+#### Step #3 Technical screening
+1. We publish the distribution. 
+2. Students contact mentors. 
+3. Mentors conduct Technical screening within two weeks from the student distribution day
+#### Step #4 Troubleshooting
+- Opportunity for mentor to transfer extra students. For example, all turned out to be capable, but the mentor cannot teach all of them
+- Location coordinators check that all active students have received mentors 
+- Opportunity for mentor to pick up students instead of those who didn't show up for the interview 
+- Student changed their mind about continuing education or switched to short track after random distribution occurred
+- After random distribution, mentor wrote that they cannot participate in mentoring
+- Exchange of students between mentors. For example, due to time zone, etc.
+#### Step #5 Picking Students from Waitlist
+Waitlist — a list of students who either were not invited to an interview, or were rejected by a mentor after the interview. From this list, mentors, if they have capacity, can pick up students.
+
+### 2.2. Picking Students from Waitlist
+1. Open https://app.rs.school/ 
+2. Click "Interviews"
+3. Click "Available students"
+4. Click "Want To Interview"
+5. Contact the student yourself (they don't receive notifications). 
+6. If you're ready to take a student without an interview - submit an empty [feedback form](https://app.rs.school/course/mentor/interview-technical-screening?course=js-fe-2021Q3), selecting "Yes, I do." in the Resume section
+
+### 2.3. Pair Mentoring
+Mentors can join together and mentor students jointly. In this case, students are still assigned to a specific mentor, but mentors in the combined group can review assignments as convenient. For example, review assignments and conduct meetings in turns.
+
+### 2.4. Gentleman's Agreement
+Mentors have priority right to hire students they teach to their company/project/team.
+
+### Pay it forward
+The school operates on the "Pay it forward" principle. According to this principle, we expect that students who studied at the school for free return as mentors to pass on their knowledge to the next generation of students.

--- a/docs/en/mentoring.md
+++ b/docs/en/mentoring.md
@@ -1,0 +1,76 @@
+# Mentoring
+Mentoring begins after conducting Technical screening, as a result of which the mentor forms a group of 2-6 students.
+
+During the first week of mentoring, the mentor needs to:
+- Create a communication channel with their students (in Discord, Telegram, etc.)
+- Schedule a weekly meeting with their students
+- Familiarize themselves with the rules of interaction between students and mentors
+- Read the [algorithm for reviewing student PRs](pull-request-review-process.md)
+- Bookmark the curriculum - [stage#2](https://github.com/rolling-scopes-school/tasks/tree/master/stage2)
+
+### Basic Rules of Interaction Between Students and Mentors
+- Communication is initiated by the student. The student must be self-motivated to learn.
+- Completed student work must be reviewed by the mentor within one to two weeks.
+- Review of completed work is done through review of corresponding Pull Requests. [Algorithm for reviewing student PRs](pull-request-review-process.md)
+- Most questions students ask in corresponding Discord channels, not their mentor. [More about Discord channel organization](rs-school-chats.md).
+
+### Weekly Meeting with Students
+- Can be conducted with all students at once or in 1-on-1 format.
+- Can be conducted online (Skype, Google Hangouts, etc.) or offline.
+- Standard meeting duration is 60 - 90 minutes
+- The meeting must be added to your calendar and students' calendars.
+- Before the meeting, you need to review open Pull Requests from students. Leave your comments. Each PR should have at least three of your comments.
+- Example meeting plan:
+  - Introduction, discussion of news.
+  - Discussion of topics, curriculum modules. 
+  - Discussion of Code review results.
+  - Additional topics. For example:
+      - resume/self-presentation preparation and interview process
+      - framework choice - React/Angular/etc
+      - scrum, patterns, etc.
+  - Answering student questions 
+
+### Weekly Mentor Activities
+- Mentor reviews and evaluates student work through review of corresponding student Pull Requests. As a result, each student's PR contains mentor comments on the code, recommendations, and a final grade. Each PR should have at least three of your comments. The grade is set by the mentor based on the evaluation criteria specified for each assignment. After review, the mentor enters the grade into the Score form, based on which the Public Score is generated. [Algorithm for reviewing student PRs](pull-request-review-process.md)
+- Conducting meetings, answering student questions.
+- If the mentor has fewer than two students or the mentor is ready to take more, they can pick up students from the Waitlist.
+
+### Deadlines for Students
+- Deadlines for all tasks are indicated in the course schedule.
+- If a student didn't submit an assignment on time, the mentor can, at their discretion, apply the following penalties:
+    - -10 points to the grade for delays up to 3 days inclusive
+    - -30% to the grade for delays up to 7 days inclusive
+    - -70% to the grade for delays more than a week
+    - at the mentor's discretion, if there's a valid reason (hospital, military training, etc.)
+    - When applying penalty coefficients, rounding is done in favor of the student
+
+### Deadlines for Mentors 
+It's expected that the mentor reviews the student's work within one to two weeks after the student submits the work. But the sooner, the better. Student deadline dates are indicated in the schedule.
+
+### FAQ
+#### Question: Are more mentors needed?
+Answer: Yes, mentors are constantly needed. 🔥 Registration here - https://app.rs.school/registry/mentor
+
+#### Question: I don't have time to conduct CoreJS Interview or Technical screening. What to do?
+- You need to warn students about the delay
+
+#### Question: I want to go on vacation. What to do?
+- You need to warn students
+
+#### Question: Where can I pick up more students?
+If you want to take another student for an interview:
+1. Open https://app.rs.school/ 
+2. Click "Interviews"
+3. Click "Available students"
+4. Click "Want To Interview"
+5. Contact the student yourself (as the student may have notifications disabled)
+
+#### Question: What to do if I can't continue mentoring on the course?
+- You need to warn the course administrator
+
+### In case of any problem, you can:
+- Write a message in the mentor Telegram 
+
+### Pay it forward
+The school operates on the "Pay it forward" principle. According to this principle, we expect that students who studied at the school for free return as mentors to pass on their knowledge to the next generation of students.
+


### PR DESCRIPTION
- Add mentoring-kick-off.md (Registration and Getting Students)
- Add mentoring-first-interview.md (First Interview / Technical screening)
- Add mentoring.md (Mentoring Process)
- Update docsMenu_en.json to include full Mentoring section matching RU version

This PR syncs the mentoring documentation section between RU and EN versions, providing English-speaking mentors with the same detailed information available in Russian.